### PR TITLE
fix: Use http keep-alive to reduce conn errors

### DIFF
--- a/src/utils/utils.mts
+++ b/src/utils/utils.mts
@@ -1,8 +1,15 @@
 import chalk from "chalk";
 import fetch from "node-fetch";
 import { Response } from "node-fetch";
+import http from "http";
+import https from "https";
 
 import { CircleCIPaginatedAPIResponse } from "./circleci.mjs";
+
+// Inspired by https://stackoverflow.com/a/62500224
+const httpAgent = new http.Agent({ keepAlive: true });
+const httpsAgent = new https.Agent({ keepAlive: true });
+const agent = (_parsedURL: URL) => _parsedURL.protocol == 'http:' ? httpAgent : httpsAgent;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function exitWithError(message: string, ...optionalParams: any[]) {
@@ -22,7 +29,7 @@ export async function fetchWithToken<T>(
       : { "Circle-Token": `${token}` };
   if (wait > 0)
     await new Promise((resolve) => setTimeout(resolve, wait * 1000));
-  const response = await fetch(url, { headers });
+  const response = await fetch(url, { headers, agent });
   let responseBody;
 
   try {

--- a/src/utils/utils.mts
+++ b/src/utils/utils.mts
@@ -9,7 +9,8 @@ import { CircleCIPaginatedAPIResponse } from "./circleci.mjs";
 // Inspired by https://stackoverflow.com/a/62500224
 const httpAgent = new http.Agent({ keepAlive: true });
 const httpsAgent = new https.Agent({ keepAlive: true });
-const agent = (_parsedURL: URL) => _parsedURL.protocol == 'http:' ? httpAgent : httpsAgent;
+const agent = (_parsedURL: URL) =>
+  _parsedURL.protocol == "http:" ? httpAgent : httpsAgent;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function exitWithError(message: string, ...optionalParams: any[]) {


### PR DESCRIPTION
`fetch` do not reuse HTTP connection by default, which means every new request would be a new HTTP connection to the server. Setting `keepAlive: true`, would make `fetch` reuse existing established connection as much as possible, which should eliminate most of the connection closed, EAI_AGAIN sort of errors.

Tested personally on hundreds of repositories without problem, which previously unable to complete.