### PR TITLE
Prevent getCircleCIRepos from going in infinite loop

### DIFF
--- a/src/index.mts
+++ b/src/index.mts
@@ -121,10 +121,15 @@ for (let index = 0; index < accounts.length; index++) {
 
   // Fetching Org Project information
   console.log("  " + chalk.italic("Fetching Projects..."));
+  // /api/private has a bug where it could return duplicate projects over multiple pages
+  const isSameProject = (prj1 : any, prj2: any) : boolean => {
+    return prj1.id === prj2.id
+  };
   const RepoList = await getPaginatedData<CircleCIResponseRepo>(
     CIRCLE_TOKEN,
     account.id,
-    getCircleCIRepos
+    getCircleCIRepos,
+    isSameProject
   );
 
   console.log("  " + chalk.italic("Fetching Project Variables..."));


### PR DESCRIPTION
Fixes issue #35

At least two people have been affected by an odd bug, following the refactoring
PR #24 that uses CircleCI's /api/private instead of GitHub's api to fetch the
repositories. Quoting one of the bug reporters:

> When the API endpoint reaches the last page it seems to just keep returning
> page tokens with the same repos it already returned earlier, resulting in
> infinite duplicates.

This PR introduces a check to stop processing projects when if finds the first
duplicates. It assumes all projects have been fecthed by there and there is
nothing else missed.
