### PR TITLE
V2/generate report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,12 @@ workflows:
     jobs:
       - node/run:
           npm-run: lint
+          name: "Lint"
       - node/run:
           npm-run: test
+          name: "Test"
       - build:
-          name: "Staging"
+          name: "Docker Staging"
           docker-namespace: ccitest
           docker-repo: cci-env-inspector
           filters:
@@ -17,7 +19,7 @@ workflows:
               ignore:
                 - main
       - build:
-          name: "Deploy"
+          name: "Docker Deploy"
           docker-namespace: circlecipublic
           docker-repo: cci-env-inspector
           filters:

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "jest": "^29.4.0",
         "prettier": "2.8.2",
         "rimraf": "^3.0.2",
+        "strip-ansi": "^7.0.1",
         "ts-jest": "^29.0.5",
         "tsup": "^6.5.0",
         "typescript": "^4.9.4"
@@ -979,6 +980,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@jest/core/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/core/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1008,6 +1018,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jest/core/node_modules/type-fest": {
@@ -1147,6 +1169,15 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@jest/reporters/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/reporters/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1176,6 +1207,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jest/schemas": {
@@ -1929,11 +1972,14 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/ansi-styles": {
@@ -2469,6 +2515,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cliui/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2499,6 +2554,18 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -3291,6 +3358,14 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/eslint/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/eslint/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3338,6 +3413,17 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/espree": {
@@ -3997,31 +4083,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/inquirer/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/inquirer/node_modules/strip-ansi": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/is-arrayish": {
@@ -8389,31 +8450,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ora/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ora/node_modules/strip-ansi": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -9122,6 +9158,27 @@
         "node": ">=10"
       }
     },
+    "node_modules/string-length/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-length/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -9138,18 +9195,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
+    "node_modules/strip-ansi": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
       "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
@@ -9161,17 +9207,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/strip-bom": {
@@ -9743,31 +9778,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -9837,6 +9847,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/yargs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -9852,6 +9871,18 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -10585,6 +10616,12 @@
             "type-fest": "^0.21.3"
           }
         },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -10602,6 +10639,15 @@
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
           }
         },
         "type-fest": {
@@ -10711,6 +10757,12 @@
             "@jridgewell/sourcemap-codec": "1.4.14"
           }
         },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -10728,6 +10780,15 @@
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
           }
         }
       }
@@ -11315,9 +11376,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
     },
     "ansi-styles": {
       "version": "6.2.1",
@@ -11682,6 +11743,12 @@
         "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -11706,6 +11773,15 @@
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
             "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
           }
         },
         "wrap-ansi": {
@@ -12132,6 +12208,11 @@
         "text-table": "^0.2.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -12162,6 +12243,14 @@
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
           "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
         }
       }
     },
@@ -12686,21 +12775,6 @@
         "strip-ansi": "^7.0.1",
         "through": "^2.3.6",
         "wrap-ansi": "^8.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
-        },
-        "strip-ansi": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-          "requires": {
-            "ansi-regex": "^6.0.1"
-          }
-        }
       }
     },
     "is-arrayish": {
@@ -15697,21 +15771,6 @@
         "log-symbols": "^5.1.0",
         "strip-ansi": "^7.0.1",
         "wcwidth": "^1.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
-        },
-        "strip-ansi": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-          "requires": {
-            "ansi-regex": "^6.0.1"
-          }
-        }
       }
     },
     "os-tmpdir": {
@@ -16184,6 +16243,23 @@
       "requires": {
         "char-regex": "^1.0.2",
         "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
       }
     },
     "string-width": {
@@ -16194,29 +16270,14 @@
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
         "strip-ansi": "^7.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
-        },
-        "strip-ansi": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-          "requires": {
-            "ansi-regex": "^6.0.1"
-          }
-        }
       }
     },
     "strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
       "requires": {
-        "ansi-regex": "^5.0.1"
+        "ansi-regex": "^6.0.1"
       }
     },
     "strip-bom": {
@@ -16605,21 +16666,6 @@
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
         "strip-ansi": "^7.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
-        },
-        "strip-ansi": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-          "requires": {
-            "ansi-regex": "^6.0.1"
-          }
-        }
       }
     },
     "wrappy": {
@@ -16670,6 +16716,12 @@
         "yargs-parser": "^21.1.1"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -16685,6 +16737,15 @@
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
             "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "jest": "^29.4.0",
     "prettier": "2.8.2",
     "rimraf": "^3.0.2",
+    "strip-ansi": "^7.0.1",
     "ts-jest": "^29.0.5",
     "tsup": "^6.5.0",
     "typescript": "^4.9.4"

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,15 +4,15 @@ import inquirer from "inquirer";
 import {
   CircleCI,
   CircleCIAccountReport,
-  CircleCICollaboration,
+  CircleCIAPICollaboration,
+  CircleCIAPIUser,
   CircleCIEnvInspectorReport,
-  CircleCIUser,
 } from "./utils/CircleCI";
 import { exitOnError, printMessage } from "./utils/Utils";
 
 type UserInput = {
-  user: CircleCIUser;
-  accounts: CircleCICollaboration[];
+  user: CircleCIAPIUser;
+  accounts: CircleCIAPICollaboration[];
   token: string;
   client: CircleCI;
 };
@@ -44,14 +44,14 @@ const getUserInput = async (): Promise<UserInput> => {
     })
     .catch((e) => {
       exitOnError(e, "Failed to authenticate");
-    })) as CircleCIUser;
+    })) as CircleCIAPIUser;
 
   // Get all collaborations
-  const collaborations: CircleCICollaboration[] = (await client
+  const collaborations: CircleCIAPICollaboration[] = (await client
     .getCollaborations()
     .catch((e) => {
       exitOnError(e, "Failed to fetch collaborations");
-    })) as CircleCICollaboration[];
+    })) as CircleCIAPICollaboration[];
   printMessage(`${collaborations.length}`, "Accounts found:");
 
   // Select from collaborations
@@ -69,7 +69,7 @@ const getUserInput = async (): Promise<UserInput> => {
         }),
       },
     ])
-  ).collaborations as CircleCICollaboration[];
+  ).collaborations as CircleCIAPICollaboration[];
   if (!selectedCollbs.length) {
     exitOnError(new Error("No collaborations selected"));
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ const getUserInput = async (): Promise<UserInput> => {
 const generateReport = async (
   userInput: UserInput
 ): Promise<CircleCIEnvInspectorReport> => {
-  const { client, user } = userInput;
+  const { client, user, accounts } = userInput;
   const report: CircleCIEnvInspectorReport = {
     user: user,
     accounts: [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ const generateReport = async (
     user: user,
     accounts: [],
   };
-  for (const account of userInput.accounts) {
+  for (const account of accounts) {
     const accountReport: CircleCIAccountReport = {
       name: account.name,
       id: account.id,

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ const getUserInput = async (): Promise<UserInput> => {
       },
     ])
   ).collaborations as CircleCIAPICollaboration[];
-  if (!selectedCollbs.length) {
+  if (!selectedCollbs || selectedCollbs.length === 0) {
     exitOnError(new Error("No collaborations selected"));
   }
   printMessage(`${selectedCollbs.length}`, "Accounts selected:");

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,7 @@ const generateReport = async (
       contexts: [],
       projects: [],
     };
-    const contexts = await client.getContexts(account.id);
+    const contexts = await client.getContexts(account.id, account.slug);
     accountReport.contexts = contexts;
     // const repos = await client.getRepos(account.id);
 

--- a/src/utils/CircleCI.ts
+++ b/src/utils/CircleCI.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosInstance } from "axios";
 import https from "https";
 
-import { printError, printMessage } from "./Utils";
+import { printError, printMessage, printWarning } from "./Utils";
 
 export class CircleCI {
   static readonly endpoint = {
@@ -75,8 +75,8 @@ export class CircleCI {
     const contexts = await this._getPaginated<CircleCIAPIContext>(
       `${CircleCI.endpoint.v2}/context?owner-id=${orgID}`
     ).catch((e) => {
-      printError(e.message, "Error fetching contexts", false, 2);
-      printError("Skipping contexts", "Warning", true, 2);
+      printError(e.message, "Error fetching contexts", 2);
+      printWarning("Skipping contexts", "Warning", 2);
       return [];
     });
     printMessage(`${contexts.length}`, "Contexts found:");
@@ -93,8 +93,8 @@ export class CircleCI {
           `${CircleCI.endpoint.v2}/context/${contexts[i].id}/environment-variable`
         );
       } catch (e) {
-        printError(`${e}`, "Error fetching context variables: ", false, 2);
-        printError("Skipping context variables", "Warning: ", true, 2);
+        printError(`${e}`, "Error fetching context variables: ", 2);
+        printError("Skipping context variables", "Warning: ", 2);
       }
       contextsReport.push({
         ...contexts[i],

--- a/src/utils/CircleCI.ts
+++ b/src/utils/CircleCI.ts
@@ -81,24 +81,27 @@ export class CircleCI {
     });
     printMessage(`${contexts.length}`, "Contexts found:");
 
-    // Potential here for too many requests
-    const promises = contexts.map(async (context) => {
+    for (let i = 0; i < contexts.length; i++) {
+      printMessage(
+        `${contexts[i].name} ${i + 1}/${contexts.length}`,
+        `Featching variables for:`,
+        2
+      );
       let variables: CircleCIAPIContextVariable[] = [];
       try {
         variables = await this._getPaginated<CircleCIAPIContextVariable>(
-          `${CircleCI.endpoint.v2}/context/${context.id}/environment-variable`
+          `${CircleCI.endpoint.v2}/context/${contexts[i].id}/environment-variable`
         );
       } catch (e) {
         printError(`${e}`, "Error fetching context variables: ", false, 2);
         printError("Skipping context variables", "Warning: ", true, 2);
       }
       contextsReport.push({
-        ...context,
-        url: `https://circleci.com/${slug}/contexts/${context.id}`,
+        ...contexts[i],
+        url: `https://circleci.com/${slug}/contexts/${contexts[i].id}`,
         variables: variables,
       });
-    });
-    await Promise.all(promises);
+    }
     return contextsReport;
   }
 }

--- a/src/utils/CircleCI.ts
+++ b/src/utils/CircleCI.ts
@@ -22,8 +22,8 @@ export class CircleCI {
     });
   }
 
-  async getAuthenticatedUser(): Promise<CircleCIUser> {
-    const response = await this._client.get<CircleCIUser>(
+  async getAuthenticatedUser(): Promise<CircleCIAPIUser> {
+    const response = await this._client.get<CircleCIAPIUser>(
       `${CircleCI.endpoint.v2}/me`
     );
     return response.data;
@@ -48,8 +48,8 @@ export class CircleCI {
     return pagedData;
   }
 
-  async getCollaborations(): Promise<CircleCICollaboration[]> {
-    const { data } = await this._client.get<CircleCICollaboration[]>(
+  async getCollaborations(): Promise<CircleCIAPICollaboration[]> {
+    const { data } = await this._client.get<CircleCIAPICollaboration[]>(
       `${CircleCI.endpoint.v2}/me/collaborations`
     );
     return data;
@@ -62,8 +62,8 @@ export class CircleCI {
    * @param orgID - The organization ID
    * @returns An array of repos
    */
-  async getRepos(orgID: string): Promise<CircleCIRepo[]> {
-    const repos = await this._getPaginated<CircleCIRepo>(
+  async getRepos(orgID: string): Promise<CircleCIAPIRepo[]> {
+    const repos = await this._getPaginated<CircleCIAPIRepo>(
       `${CircleCI.endpoint.private}/project?organization-id=${orgID}`
     );
     return repos;
@@ -71,7 +71,7 @@ export class CircleCI {
 
   async getContexts(orgID: string): Promise<CircleCIContext[]> {
     printMessage("...", "Fetching contexts");
-    const contexts = await this._getPaginated<CircleCIContext>(
+    const contexts = await this._getPaginated<CircleCIAPIContext>(
       `${CircleCI.endpoint.v2}/context?owner-id=${orgID}`
     );
     printMessage(`${contexts.length}`, "Contexts found:");
@@ -80,7 +80,7 @@ export class CircleCI {
 }
 
 // Types
-export type CircleCIUser = {
+export type CircleCIAPIUser = {
   name: string;
   login: string;
   id: string;
@@ -91,39 +91,40 @@ export type CircleCIPaginatedAPIResponse<T> = {
   items: T[];
   next_page_token: string;
 };
-export type CircleCICollaboration = {
+export type CircleCIAPICollaboration = {
   id: string;
   name: string;
   vcs_type: VCS_TYPE;
   avatar_url: string;
   slug: string;
 };
-export type CircleCIContext = {
-  name: string;
+export type CircleCIAPIContext = {
   id: string;
-  url: string;
-  variables: CircleCIContextVariable[];
+  name: string;
+  created_at: string;
 };
-export type CircleCIContextVariable = {
+export interface CircleCIContext extends CircleCIAPIContext {
+  url: string;
+  variables: CircleCIAPIContextVariable[];
+}
+export type CircleCIAPIContextVariable = {
   variable: string;
   context_id: string;
   created_at: string;
-  error?: string;
+  updated_at: string;
 };
-export type CircleCIProjectVariable = {
+export type CircleCIAPIProjectVariable = {
   name: string;
   value: string;
-  error?: string;
 };
-export type CircleCIProjectKey = {
+export type CircleCIAPIProjectKey = {
   type: string;
   preferred: string;
   created_at: string;
   public_key: string;
   fingerprint: string;
-  error?: string;
 };
-export type CircleCIRepo = {
+export type CircleCIAPIRepo = {
   id: string;
   name: string;
   slug: string;
@@ -133,8 +134,8 @@ export type CircleCIProject = {
   id: string;
   name: string;
   slug: string;
-  variables: CircleCIProjectVariable[];
-  keys: CircleCIProjectKey[];
+  variables: CircleCIAPIProjectVariable[];
+  keys: CircleCIAPIProjectKey[];
 };
 export type CircleCICollabData = {
   name: string;
@@ -143,7 +144,7 @@ export type CircleCICollabData = {
   projects: CircleCIProject[];
 };
 export type CircleCIEnvInspectorReport = {
-  user: CircleCIUser;
+  user: CircleCIAPIUser;
   accounts: CircleCIAccountReport[];
 };
 export type CircleCIAccountReport = {

--- a/src/utils/CircleCI.ts
+++ b/src/utils/CircleCI.ts
@@ -1,6 +1,8 @@
 import axios, { AxiosInstance } from "axios";
 import https from "https";
 
+import { printMessage } from "./Utils";
+
 export class CircleCI {
   static readonly endpoint = {
     v1: "https://circleci.com/api/v1.1",
@@ -8,6 +10,7 @@ export class CircleCI {
     private: "https://circleci.com/api/private",
   };
   private _client: AxiosInstance;
+
   constructor(token: string) {
     this._client = axios.create({
       headers: {
@@ -18,12 +21,14 @@ export class CircleCI {
       }),
     });
   }
+
   async getAuthenticatedUser(): Promise<CircleCIUser> {
     const response = await this._client.get<CircleCIUser>(
       `${CircleCI.endpoint.v2}/me`
     );
     return response.data;
   }
+
   /**
    * Fetches paginated data from the CircleCI API
    * @param url - The endpoint to fetch
@@ -62,6 +67,15 @@ export class CircleCI {
       `${CircleCI.endpoint.private}/project?organization-id=${orgID}`
     );
     return repos;
+  }
+
+  async getContexts(orgID: string): Promise<CircleCIContext[]> {
+    printMessage("...", "Fetching contexts");
+    const contexts = await this._getPaginated<CircleCIContext>(
+      `${CircleCI.endpoint.v2}/context?owner-id=${orgID}`
+    );
+    printMessage(`${contexts.length}`, "Contexts found:");
+    return contexts;
   }
 }
 
@@ -130,13 +144,12 @@ export type CircleCICollabData = {
 };
 export type CircleCIEnvInspectorReport = {
   user: CircleCIUser;
-  accounts: [
-    {
-      name: string;
-      id: string;
-      vcstype: VCS_TYPE;
-      contexts: CircleCIContext[];
-      projects: CircleCIProject[];
-    }
-  ];
+  accounts: CircleCIAccountReport[];
+};
+export type CircleCIAccountReport = {
+  name: string;
+  id: string;
+  vcstype: VCS_TYPE;
+  contexts: CircleCIContext[];
+  projects: CircleCIProject[];
 };

--- a/src/utils/CircleCI.ts
+++ b/src/utils/CircleCI.ts
@@ -128,3 +128,15 @@ export type CircleCICollabData = {
   contexts: CircleCIContext[];
   projects: CircleCIProject[];
 };
+export type CircleCIEnvInspectorReport = {
+  user: CircleCIUser;
+  accounts: [
+    {
+      name: string;
+      id: string;
+      vcstype: VCS_TYPE;
+      contexts: CircleCIContext[];
+      projects: CircleCIProject[];
+    }
+  ];
+};

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -13,8 +13,16 @@ export function printMessage(message: string, title?: string, indent?: number) {
   console.log(chalk.bold(`${indentStyled}${titleStyled} ${message}`));
 }
 
-export function printError(message: string, title?: string, indent?: number) {
-  const titleStyled = title ? chalk.red(title) : "";
+export function printError(
+  message: string,
+  title?: string,
+  isWarning = false,
+  indent?: number
+) {
+  let titleStyled = title ? title : "";
+  isWarning
+    ? (titleStyled = chalk.yellow(titleStyled))
+    : (titleStyled = chalk.red(titleStyled));
   const indentStyled = indent ? " ".repeat(indent) : "";
   console.error(chalk.bold(`${indentStyled}${titleStyled} ${message}`));
 }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1,10 +1,9 @@
 import chalk from "chalk";
 
-export function exitOnError(e: Error, title?: string) {
-  console.error(
-    chalk.bold.red(title ?? "Fatal error: "),
-    chalk.bold(e.message ?? e ?? "Unknown error")
-  );
+export function exitOnError(e: Error, title?: string, indent?: number) {
+  const titleStyled = title ? chalk.red(title) : "";
+  const indentStyled = indent ? " ".repeat(indent) : "";
+  console.error(chalk.bold(`${indentStyled}${titleStyled} ${e.message}`));
   process.exit(1);
 }
 
@@ -12,4 +11,10 @@ export function printMessage(message: string, title?: string, indent?: number) {
   const titleStyled = title ? chalk.green(title) : "";
   const indentStyled = indent ? " ".repeat(indent) : "";
   console.log(chalk.bold(`${indentStyled}${titleStyled} ${message}`));
+}
+
+export function printError(message: string, title?: string, indent?: number) {
+  const titleStyled = title ? chalk.red(title) : "";
+  const indentStyled = indent ? " ".repeat(indent) : "";
+  console.error(chalk.bold(`${indentStyled}${titleStyled} ${message}`));
 }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -7,3 +7,9 @@ export function exitOnError(e: Error, title?: string) {
   );
   process.exit(1);
 }
+
+export function printMessage(message: string, title?: string, indent?: number) {
+  const titleStyled = title ? chalk.green(title) : "";
+  const indentStyled = indent ? " ".repeat(indent) : "";
+  console.log(chalk.bold(`${indentStyled}${titleStyled} ${message}`));
+}

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -7,26 +7,30 @@ export function exitOnError(e: Error, title?: string, indent?: number) {
   process.exit(1);
 }
 
-export function printMessage(message: string, title?: string, indent?: number) {
-  const titleStyled = title ? chalk.green(title) : "";
-  const indentStyled = indent ? " ".repeat(indent) : "";
-  console.log(chalk.bold(`${indentStyled}${titleStyled} ${message}`));
-}
-
-export function printError(
+function print(
   message: string,
+  log: Console["warn"] | Console["error"] | Console["log"],
   title?: string,
-  isWarning = false,
   indent?: number
 ) {
   let titleStyled = title ? title : "";
-  isWarning
-    ? (titleStyled = chalk.yellow(titleStyled))
-    : (titleStyled = chalk.red(titleStyled));
+
+  if (log.name === "warn") titleStyled = chalk.yellow(titleStyled);
+  else if (log.name === "error") titleStyled = chalk.red(titleStyled);
+  else titleStyled = chalk.green(titleStyled);
+
   const indentStyled = indent ? " ".repeat(indent) : "";
-  if (isWarning) {
-    console.warn(chalk.bold(`${indentStyled}${titleStyled} ${message}`));
-  } else {
-    console.error(chalk.bold(`${indentStyled}${titleStyled} ${message}`));
-  }
+  log(chalk.bold(`${indentStyled}${titleStyled} ${message}`));
+}
+
+export function printMessage(message: string, title?: string, indent?: number) {
+  print(message, console.log, title, indent);
+}
+
+export function printWarning(message: string, title?: string, indent?: number) {
+  print(message, console.warn, title, indent);
+}
+
+export function printError(message: string, title?: string, indent?: number) {
+  print(message, console.error, title, indent);
 }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -24,5 +24,9 @@ export function printError(
     ? (titleStyled = chalk.yellow(titleStyled))
     : (titleStyled = chalk.red(titleStyled));
   const indentStyled = indent ? " ".repeat(indent) : "";
-  console.error(chalk.bold(`${indentStyled}${titleStyled} ${message}`));
+  if (isWarning) {
+    console.warn(chalk.bold(`${indentStyled}${titleStyled} ${message}`));
+  } else {
+    console.error(chalk.bold(`${indentStyled}${titleStyled} ${message}`));
+  }
 }

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1,0 +1,34 @@
+import { printError, printMessage, printWarning } from "../src/utils/Utils";
+import { jest } from "@jest/globals";
+import stripAnsi from "strip-ansi";
+
+describe("printMessage", () => {
+  it("should call console.log with the correct message", () => {
+    const spy = jest.spyOn(console, "log");
+    printMessage("Hello world", "Message", 2);
+    expect(stripAnsi(spy.mock.calls[0][0])).toEqual("  Message Hello world");
+    spy.mockRestore();
+  });
+});
+
+describe("printWarning", () => {
+  it("should call console.warn with the correct message", () => {
+    const spy = jest.spyOn(console, "warn");
+    printWarning("A warning occurred", "Warning", 2);
+    expect(stripAnsi(spy.mock.calls[0][0])).toEqual(
+      "  Warning A warning occurred"
+    );
+    spy.mockRestore();
+  });
+});
+
+describe("printError", () => {
+  it("should call console.error with the correct message", () => {
+    const spy = jest.spyOn(console, "error");
+    printError("An error occurred", "Error", 2);
+    expect(stripAnsi(spy.mock.calls[0][0])).toEqual(
+      "  Error An error occurred"
+    );
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
This is a big jump in changes (sorry, many things depended on each other) that brings some minimum functionality to the v2 branch, beginning withing generating the report and populating contexts and their variables within.

- Split the `main` function into two async functions
    - `getUserInput` gets the parameters from the user and configures the Axios client
    - Which then is passed to `generateReport`, which could now be tested without the need for user input and a mock client could be injected
- Generate Report (defined schema)
- Fetch contexts and containing variables
- Improved error handling
- Refactored/Improved Error message printing
    - It was getting difficult to locate which `console.log` statements were intentional or not, the new `printMessage` function shows an intentional line print with styling and further reduces duplicate code.