### PR TITLE
feat(v2): detect legacy AWS keys

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,7 @@ const generateReport = async (
     };
     accountReport.contexts = await client.getContexts(account.id, account.slug);
     accountReport.projects = await client.getProjects(account.id);
+
     report.accounts.push(accountReport);
   }
   return report;


### PR DESCRIPTION
Pull Legacy AWS keys from project settings via the v1.1 API. Note: Ideally this should be tested with an account that still has these legacy keys.

This resolves #52 - @kelvintaywl if it would be possible to test this branch, that would be a big help! Please note that this branch is for the v2 of the product which is not yet ready for _full_ release and may yet still have some unrelated bugs.