### PR TITLE
feat: improve authentication error handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,10 +36,10 @@ const getUserInput = async (): Promise<UserInput> => {
   const user = (await client
     .getAuthenticatedUser()
     .then((user) => {
-      if (!user.name) {
+      if (!user.name && !user.login) {
         exitWithError(new Error(JSON.stringify(user)), "No username returned");
       }
-      printMessage(user.name, "Successfully authenticated as:");
+      printMessage(user.name ?? user.login, "Successfully authenticated as:");
       return user;
     })
     .catch((e) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,13 +37,13 @@ const getUserInput = async (): Promise<UserInput> => {
     .getAuthenticatedUser()
     .then((user) => {
       if (!user.name) {
-        exitWithError(new Error("No user name returned"));
+        exitWithError(new Error(JSON.stringify(user)), "No username returned");
       }
-      printMessage(user.name, "Sucessfully authenticated as:");
+      printMessage(user.name, "Successfully authenticated as:");
       return user;
     })
     .catch((e) => {
-      exitWithError(e, "Failed to authenticate");
+      exitWithError(e, "Fatally failed to authenticate:");
     })) as CircleCIAPIUser;
 
   // Get all collaborations

--- a/src/utils/CircleCI.ts
+++ b/src/utils/CircleCI.ts
@@ -31,9 +31,13 @@ export class CircleCI {
   }
 
   async getAuthenticatedUser(): Promise<CircleCIAPIUser> {
-    const response = await this._client.get<CircleCIAPIUser>(
-      `${CircleCI.endpoint.v2}/me`
-    );
+    const response = await this._client
+      .get<CircleCIAPIUser>(`${CircleCI.endpoint.v2}/me`)
+      .catch((e) => {
+        const error = getAxiosError(e);
+        printAxiosError(error, 2, "Authentication failed:");
+        throw error;
+      });
     return response.data;
   }
 


### PR DESCRIPTION
When an invalid API token is present, or the API returns any failed status code, the output will now show:

```
API Request Error: 401 Unauthorized https://circleci.com/api/v2/me
Fatally failed to authenticate: Request failed with status code 401
```

<img width="473" alt="image" src="https://user-images.githubusercontent.com/33272306/217558889-08df6bc8-42db-45ce-be4a-6cdf0e5bf91b.png">

If the request is successful, but the `name` is not found on the result, we will now display the whole user object in the output for debugging.


---

solves #68 