### PR TITLE
fix: add validation for gitlab slug

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,10 @@ const getUserInput = async (): Promise<UserInput> => {
         message: "Select accounts: \n",
         choices: collaborations.map((collab) => {
           return {
-            name: ` ${collab.slug}`,
+            name:
+              collab.vcs_type == "circleci"
+                ? ` gl/${collab.name}`
+                : ` ${collab.slug}`,
             value: collab,
           };
         }),


### PR DESCRIPTION
Currently, any GitLab account appears in the selection prompt as an ID. This `PR` adds validation for any `GitLab` accounts and returns the correct slug. 